### PR TITLE
Do not pass arguments to MainLoop.run_training()

### DIFF
--- a/emloop_tensorflow/tests/frozen_model_test.py
+++ b/emloop_tensorflow/tests/frozen_model_test.py
@@ -60,7 +60,7 @@ def test_frozen_model_run(tmpdir):
     dataset = SimpleDataset()
     model = TrainableModel(dataset=dataset, log_dir=tmpdir, **_IO, freeze=True, optimizer=_OPTIMIZER)
     mainloop = MainLoop(model=model, dataset=dataset, hooks=[StopAfter(epochs=1000)], skip_zeroth_epoch=False)
-    mainloop.run_training(None)
+    mainloop.run_training()
     model.save('')
 
     frozen_model = FrozenModel(inputs=['input'], outputs=['output'], restore_from=tmpdir)


### PR DESCRIPTION
The tests are expected to fail on archlinux, since there is a problem with a wrong dependency in TensorFlow 1.13.0.